### PR TITLE
fix image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,4 @@ This server project provides an API that developers can use to develop bots that
  * All matching choices will be a tie with the same choice by opponent.
  * Each bot may also throw a water balloon whenever it likes.
 
-![game uml][game_diagram]
-
-[game_diagram]:(docs/game_diagram.png)
+![game uml](docs/game_diagram.png)


### PR DESCRIPTION
Removed the alias and put the link to the diagram image directly in-line, and I figured out how to preview it from my fork to confirm it's correct! 💯 

I'm still not exactly sure why the reference got wrapped in parens when I used the alias. Couldn't find a difference between my markdown and the online examples I was looking at.