### PR TITLE
Sync About.cshtml with README

### DIFF
--- a/src/RockPaperScissorsBoom.Server/Pages/About.cshtml
+++ b/src/RockPaperScissorsBoom.Server/Pages/About.cshtml
@@ -14,10 +14,10 @@
     <li>Rock beats Scissors</li>
     <li>Scissors beats Paper</li>
     <li>Paper beats Rock</li>
-    <li>A bomb will defeat Rock, Paper, or Scissors played by the opponent.</li>
-    <li>A water balloon will defeat a bomb.</li>
+    <li>A dynamite will defeat Rock, Paper, or Scissors played by the opponent.</li>
+    <li>A water balloon will defeat a dynamite.</li>
     <li>Rock, Paper, and Scissors all beat water balloon.</li>
-    <li>Each bot receives 100 bombs to use during a match.</li>
+    <li>Each bot receives 100 dynamites to use during a match.</li>
     <li>All matching choices will be a tie with the same choice by opponent.</li>
     <li>Each bot may also throw a water balloon whenever it likes.</li>
 </ul>


### PR DESCRIPTION
Readme text was pulled from the about page, so changes to the relevant sections should also be made to About.cshtml.
Is there a way to automate/warn about this? Would if we just made the About page a link to the readme?